### PR TITLE
Adding Cloud Scheduler for Arbitrum LLO node

### DIFF
--- a/Cloud_Schedulers/LLO/arbitrum/data.tf
+++ b/Cloud_Schedulers/LLO/arbitrum/data.tf
@@ -1,0 +1,8 @@
+// Data sources to pull service account details from secrests manager
+
+data "google_secret_manager_secret_version" "sa" {
+  provider = google-beta
+  secret   = var.service_account_name
+  version  = var.service_account_version
+  project  = var.project_id
+}

--- a/Cloud_Schedulers/LLO/arbitrum/main.tf
+++ b/Cloud_Schedulers/LLO/arbitrum/main.tf
@@ -1,0 +1,27 @@
+resource "google_cloud_scheduler_job" "job" {
+  name             = "cs-${var.node_name}"
+  description      = "${var.node_name} ${var.scheduler_job_description}"
+  schedule         = var.scheduler_job_schedule
+  time_zone        = var.scheduler_job_time_zone
+  attempt_deadline = var.scheduler_job_attempt_deadline
+
+  retry_config {
+    retry_count = var.retry_config_retry_count
+    max_retry_duration = var.retry_config_max_retry_duration
+    max_backoff_duration = var.retry_config_max_max_backoff_duration
+    min_backoff_duration = var.retry_config_max_min_backoff_duration
+    max_doublings = var.retry_config_max_doublings
+  }
+
+  http_target {
+    http_method = var.http_method
+    headers = {
+      "User-Agent" = var.User-Agent
+    }
+    uri         = var.uri
+    oauth_token {
+      service_account_email = data.google_secret_manager_secret_version.sa.secret_data // Service account details pulled from secrets manager
+      scope = var.scope
+    }
+  }
+}

--- a/Cloud_Schedulers/LLO/arbitrum/provider.tf
+++ b/Cloud_Schedulers/LLO/arbitrum/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project     = var.project_id
+  credentials = file("../../../service_account.json")
+  region = var.region
+}

--- a/Cloud_Schedulers/LLO/arbitrum/state.tf
+++ b/Cloud_Schedulers/LLO/arbitrum/state.tf
@@ -1,0 +1,6 @@
+terraform {
+    backend "gcs" {
+      bucket  = "myc-node"
+      prefix  = "cl/cloud-schedulers/FM/arbitrum-ocr-llo.tfstate"
+    }
+  }

--- a/Cloud_Schedulers/LLO/arbitrum/variables.tf
+++ b/Cloud_Schedulers/LLO/arbitrum/variables.tf
@@ -1,0 +1,57 @@
+variable "service_account_name" {
+  description = "Service account name"
+  default     = "Cloud_Schedulers_Service_Account"
+}
+variable "service_account_version" {
+  description = "Service account version"
+  default     = "1"
+}
+variable "project_id" {
+  description = "The gcp project ID where the resources need to be deployed"
+  default = "avian-direction-235610"
+}
+variable "region" {
+  default = "us-central1"
+}
+variable "scheduler_job_description" {
+  default = "node reboot"
+}
+variable "scheduler_job_schedule" {
+  default = "0 10 * * *"
+}
+variable "scheduler_job_time_zone" {
+  default = "Asia/Calcutta"
+}
+variable "scheduler_job_attempt_deadline" {
+  default = "320s"
+}
+variable "retry_config_retry_count" {
+  default = 1
+}
+variable "retry_config_max_retry_duration" {
+  default = "0s"
+}
+variable "retry_config_max_max_backoff_duration" {
+  default = "3600s"
+}
+variable "retry_config_max_min_backoff_duration" {
+  default = "5s"
+}
+variable "retry_config_max_doublings" {
+  default = 5
+}
+variable "http_method" {
+  default = "POST"
+}
+variable "User-Agent" {
+  default = "Google-Cloud-Scheduler"
+}
+variable "uri" {
+  default = "https://compute.googleapis.com/compute/v1/projects/avian-direction-235610/zones/us-central1-a/instances/cl-arbitrum-ocr-llo-1/reset"
+}
+variable "scope" {
+  default = "https://www.googleapis.com/auth/cloud-platform"
+}
+variable "node_name" {
+  default = "cl-arbitrum-ocr-llo-1"
+}


### PR DESCRIPTION
This will help clean up docker logs and disk space for the LLO Arbitrum node.
This is a temporary setup used for testing the Low Latency Oracle setup.
Will be deprecated in future